### PR TITLE
fix: mark instance_server_ca_cert output as sensitive on postgresql

### DIFF
--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -53,6 +53,7 @@ output "instance_self_link" {
 output "instance_server_ca_cert" {
   value       = google_sql_database_instance.default.server_ca_cert
   description = "The CA certificate information used to connect to the SQL instance via SSL"
+  sensitive   = true
 }
 
 output "instance_service_account_email_address" {


### PR DESCRIPTION
fix: mark instance_server_ca_cert output as sensitive on postgresql